### PR TITLE
Remove invalid WordPress API links

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,16 +650,10 @@
 			"v4_id": "G-KKZJVPEY85"
 		}; /* ]]> */
 	</script>
-	<link rel="https://api.w.org/" href="wp-json/index.html" />
-	<link rel="alternate" type="application/json" href="wp-json/wp/v2/pages/7" />
 	<link rel="EditURI" type="application/rsd+xml" title="RSD" href="xmlrpc.php@rsd" />
 	<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="SiteFoundation/wlwmanifest.xml" />
 	<meta name="generator" content="WordPress 6.2.2" />
 	<link rel='shortlink' href='index.html' />
-	<link rel="alternate" type="application/json+oembed"
-		href="wp-json/oembed/1.0/embed@url=https%253A%252F%252Fcydstumpel.nl%252F" />
-	<link rel="alternate" type="text/xml+oembed"
-		href="wp-json/oembed/1.0/embed@url=https%253A%252F%252Fcydstumpel.nl%252F&amp;format=xml" />
 	<link rel="icon" href="FlexiSpace/uploads/2023/06/cropped-logo-32x32.png" sizes="32x32" />
 	<link rel="icon" href="FlexiSpace/uploads/2023/06/cropped-logo-192x192.png" sizes="192x192" />
 	<link rel="apple-touch-icon" href="FlexiSpace/uploads/2023/06/cropped-logo-180x180.png" />


### PR DESCRIPTION
## Summary
- clean up HTML head of `index.html` by removing `wp-json` links that pointed to missing files

## Testing
- `grep -n wp-json -n index.html`