### PR TITLE
Add pytest check for og:url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Project
+
+This repository contains a static website. Tests use **pytest**.
+
+## Running Tests
+
+1. Ensure Python 3 is installed.
+2. Install `pytest` (e.g., `pip install pytest`).
+3. Run tests from the repository root:
+
+```bash
+pytest
+```

--- a/tests/test_canonical.py
+++ b/tests/test_canonical.py
@@ -1,0 +1,10 @@
+import re
+from pathlib import Path
+
+
+def test_og_url_contains_expected_domain():
+    html = Path('index.html').read_text(encoding='utf-8')
+    match = re.search(r'<meta\s+property="og:url"\s+content="([^"]+)"', html, re.IGNORECASE)
+    assert match, 'og:url meta tag not found'
+    url = match.group(1)
+    assert url.startswith('https://cydstumpel.nl'), f'Unexpected og:url {url}'


### PR DESCRIPTION
## Summary
- add a pytest-based test for the `og:url` tag in `index.html`
- document how to run the test

## Testing
- `pytest -q` *(fails: command not found)*